### PR TITLE
Potential fix for code scanning alert no. 2: Log entries created from user input

### DIFF
--- a/src/Common/Common.Web/GlobalExceptionHandler.cs
+++ b/src/Common/Common.Web/GlobalExceptionHandler.cs
@@ -12,7 +12,7 @@ public class GlobalExceptionHandler(ILogger<GlobalExceptionHandler> logger) : IE
         CancellationToken cancellationToken)
     {
         var problemDetails = new ProblemDetails();
-        problemDetails.Instance = httpContext.Request.Path;
+        problemDetails.Instance = httpContext.Request.Path.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", "");
 
         if (exception is FluentValidation.ValidationException fluentException)
         {


### PR DESCRIPTION
Potential fix for [https://github.com/budancamanak/TradeCloud/security/code-scanning/2](https://github.com/budancamanak/TradeCloud/security/code-scanning/2)

To fix the problem, we need to sanitize the user input before logging it. Since the log entries are plain text, we should remove any line breaks from the user input to prevent log forging. This can be done using the `String.Replace` method to replace newline characters with an empty string. We will apply this sanitization to `problemDetails.Instance` before it is logged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
